### PR TITLE
CUMULUS-451 fix error string length used with stepfunctions.sendTaskFailure

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ function getLambdaZip(arn, workDir, callback) {
 function downloadLambdaHandler(lambdaArn, workDir, taskDir, callback) {
   return getLambdaZip(lambdaArn, workDir, (err, filepath, moduleFileName, moduleFunctionName) => {
     if (err) return callback(err);
-  
+
     execSync(`unzip -o ${filepath} -d ${taskDir}`);
     const task = require(`${taskDir}/${moduleFileName}`); //eslint-disable-line global-require
     return callback(null, task[moduleFunctionName]);
@@ -93,9 +93,11 @@ function startHeartbeat(taskToken) {
 * @returns {undefined} - no return value
 **/
 function sendTaskFailure(taskToken, taskError) {
+  const error = taskError.toString();
   sf.sendTaskFailure({
     taskToken: taskToken,
-    error: taskError.toString()
+    error: error.substring(0, 250),
+    cause: error
   }, (err) => {
     if (err) {
       console.log('sendTaskFailure err', err);

--- a/index.js
+++ b/index.js
@@ -89,15 +89,14 @@ function startHeartbeat(taskToken) {
 * Tells workflow that the task has failed
 *
 * @param {string} taskToken - the task token
-* @param {Object} taskError - the error
+* @param {Object} taskError - the error object returned by the handler
 * @returns {undefined} - no return value
 **/
 function sendTaskFailure(taskToken, taskError) {
-  const error = taskError.toString();
   sf.sendTaskFailure({
     taskToken: taskToken,
-    error: error.substring(0, 250),
-    cause: error
+    error: taskError.name,
+    cause: taskError.message
   }, (err) => {
     if (err) {
       console.log('sendTaskFailure err', err);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/cumulus-ecs-task",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Run lambda functions in ECS",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
This fixes the validation error that happens when error strings are too long for `stepfunctions.sendTaskFailure()`