### PR TITLE
Fix activity queue timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-- 
+
+## [v1.0.2] - 2018-03-30
+- increase activity queue timeout to 65 seconds as suggested here: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/StepFunctions.html#getActivityTask-property
+
+## [v1.0.1] - 2018-03-23
+- fixes the validation error that happens when error strings are too long for stepfunctions.sendTaskFailure()
 
 ## [v1.0.0] - 2018-03-08
 
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/cumulus-nasa/cumulus-cumulus-ecs-task/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/cumulus-nasa/cumulus-cumulus-ecs-task/compare/v1.0.2...HEAD
+[v1.0.2]: https://github.com/cumulus-nasa/cumulus-cumulus-ecs-task/compare/v1.0.1...v1.0.2
+[v1.0.1]: https://github.com/cumulus-nasa/cumulus-cumulus-ecs-task/compare/v1.0.0...v1.0.1
 [v1.0.0]: https://github.com/cumulus-nasa/cumulus-ecs-task/tree/v1.0.0

--- a/index.js
+++ b/index.js
@@ -145,8 +145,8 @@ class TaskPoll extends EventEmitter {
   start() {
     // kick off sf.getActivityTask
     this.getTask();
-    // repeat every 60 seconds (the timeout of sf.getActivityTask)
-    this.intervalId = setInterval(() => this.getTask(), 60000);
+    // repeat every 65 seconds (the timeout of sf.getActivityTask)
+    this.intervalId = setInterval(() => this.getTask(), 65000);
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/cumulus-ecs-task",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Run lambda functions in ECS",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
- increase activity queue timeout to 65 seconds as suggested here: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/StepFunctions.html#getActivityTask-property