### PR TITLE
update README.md and changelog links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Initial release
 
 [Unreleased]: https://github.com/cumulus-nasa/cumulus-cumulus-ecs-task/compare/v1.0.2...HEAD
+[v1.1.1]: https://github.com/cumulus-nasa/cumulus-cumulus-ecs-task/compare/v1.1.0...v1.1.1
+[v1.1.0]: https://github.com/cumulus-nasa/cumulus-cumulus-ecs-task/compare/v1.0.2...v1.1.0
 [v1.0.2]: https://github.com/cumulus-nasa/cumulus-cumulus-ecs-task/compare/v1.0.1...v1.0.2
 [v1.0.1]: https://github.com/cumulus-nasa/cumulus-cumulus-ecs-task/compare/v1.0.0...v1.0.1
 [v1.0.0]: https://github.com/cumulus-nasa/cumulus-ecs-task/tree/v1.0.0

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ See [`cumulus-integration-tests/blob/master/app/config.yml`](https://github.com/
 
 This library requires additional configuration to be added to the app/config.yml file under the `ecs` block, as well as a list of activity names under `activities`.
 
-Here's an example deploment configuration that would be placed in app/config.yml:
+Here's an example deployment configuration that would be placed in app/config.yml:
 
 ```yml
 yourdeployment:
@@ -226,7 +226,7 @@ docker run -e AWS_ACCESS_KEY_ID='<aws-access-key>' \
 
 Finally, trigger a workflow. You can do this from the Cumulus dashboard, the Cumulus API, or with the AWS Console by supplying a 
 
-## Debugging:
+## Troubleshooting
 
 SSH into the ECS container instance.
 
@@ -246,8 +246,8 @@ Check if there's multiple entries of the config.
 
 If there is, there are two things to try:
 
-- delete the ec2 instance and redeploy
-- delete the incorrect config and restart the ecs agent (i haven't tested this much but i expect it to work. you'll still want to update the docker credentials in the deployment's app directory). Restart the agent by doing:
+- Delete the ec2 instance and redeploy
+- Delete the incorrect config and restart the ecs agent (I haven't tested this much but I expect it to work. You'll still want to update the docker credentials in the deployment's app directory). Restart the agent by doing:
   ```sh
   sudo stop ecs
   source /etc/ecs/ecs.config
@@ -256,7 +256,9 @@ If there is, there are two things to try:
 
 ## Create a release
 
-Bump the version
+To create a release, first make sure the [CHANGELOG.md](CHANGELOG.md) file is updated with all the changes made.
+
+Next, bump the version and the changes will automatically be released upon merge to master.
 
 ```
 npm version <major|minor|patch|specific version>

--- a/README.md
+++ b/README.md
@@ -77,6 +77,19 @@ Here's an example:
 
 ```yml
 yourdeployment:
+  # make sure to set these environment variables in the app/.env file
+  params:
+    - name: DockerPassword
+      value: '{{DOCKER_PASSWORD}}'
+    - name: DockerEmail
+      value: '{{DOCKER_EMAIL}}'
+    - name: CmrPassword
+      value: '{{CMR_PASSWORD}}'
+
+  # define the ECS activity
+  activities:
+    - name: EcsTaskHelloWorld
+
   ecs:
     instanceType: t2.small
     desiredInstances: 1
@@ -84,14 +97,17 @@ yourdeployment:
     amiid: ami-a7a242da
     publicIp: true
     docker: 
-      username: cumulususer
+      username: <your docker user name>
     services:
       EcsTaskHelloWorld:
-        image: cumuluss/cumulus-ecs-task:1.0.0
-        cpu: 800
-        memory: 1500
-        count: 0
+        image: cumuluss/cumulus-ecs-task:1.1.1
+        cpu: 500
+        memory: 500
+        count: 0 # increase this to increase the number of tasks
         envs:
+          # env vars needed for core cumulus modules:
+          internal: <name of internal bucket>
+          stackName: <name of deployment (in this case it would be "yourdeployment")>
           AWS_DEFAULT_REGION:
             function: Fn::Sub
             value: '${AWS::Region}'
@@ -103,15 +119,12 @@ yourdeployment:
           - '--lambdaArn'
           - function: Ref
             value: EcsTaskHelloWorldLambdaFunction
-
-  activities:
-    - name: EcsTaskHelloWorld
 ```
 
 Make sure the version on this line:
 
 ```
-image: cumuluss/cumulus-ecs-task:1.0.0
+image: cumuluss/cumulus-ecs-task:1.1.1
 ```
 
 Is the latest version available on [Docker Hub](https://hub.docker.com/r/cumuluss/cumulus-ecs-task/tags/).
@@ -137,6 +150,7 @@ The following should be included in the `Statement` of the `EcsRole` policy:
   - states:SendTaskSuccess
   - states:SendTaskHeartbeat
   - states:GetActivityTask
+  - states:GetExecutionHistory
   Resource: arn:aws:states:*:*:*
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ See [`cumulus-integration-tests/blob/master/app/config.yml`](https://github.com/
 
 This library requires additional configuration to be added to the app/config.yml file under the `ecs` block, as well as a list of activity names under `activities`.
 
-Here's an example:
+Here's an example deploment configuration that would be placed in app/config.yml:
 
 ```yml
 yourdeployment:
@@ -135,6 +135,18 @@ We can give our service the same name as the activity. Be sure to double-check t
 
 Note that under the the `commands` section we're referencing the `EcsTaskHelloWorldActivity` as the `activityArn` and the `EcsTaskHelloWorldLambdaFunction` as the `lambdaArn`.
 
+#### Docker credentials
+
+Make sure to set the docker email and password in app/.env:
+
+```
+DOCKER_PASSWORD=<your password>
+DOCKER_EMAIL=<your email>
+```
+
+**Which docker credentials should we use?**
+
+Any valid credentials to authenticate with docker's API service. It's recommended to create an organization-specific docker hub account.
 
 ### IAM permissions
 
@@ -213,6 +225,34 @@ docker run -e AWS_ACCESS_KEY_ID='<aws-access-key>' \
 ```
 
 Finally, trigger a workflow. You can do this from the Cumulus dashboard, the Cumulus API, or with the AWS Console by supplying a 
+
+## Debugging:
+
+SSH into the ECS container instance.
+
+Make sure the EC2 instance has internet access and is able to pull the image from docker hub by doing:
+
+```
+docker pull cumuluss/cumulus-ecs-task:1.1.1
+```
+
+`cat` the ecs config file to make sure credentials are correct:
+
+```
+cat /etc/ecs/ecs.config
+```
+
+Check if there's multiple entries of the config.
+
+If there is, there are two things to try:
+
+- delete the ec2 instance and redeploy
+- delete the incorrect config and restart the ecs agent (i haven't tested this much but i expect it to work. you'll still want to update the docker credentials in the deployment's app directory). Restart the agent by doing:
+  ```sh
+  sudo stop ecs
+  source /etc/ecs/ecs.config
+  sudo start ecs
+  ```
 
 ## Create a release
 


### PR DESCRIPTION
After working with @mennovandiermen on getting sync-granule working in ECS, I made these revisions to the docs to help us next time.

Some additional notes from doing the debugging:

### environment variables not found

The ingest/crypto module expects to be able to fall back on `process.env.internal` and `process.env.stackName` as values passed to s3 get/put functions.

sync-granule relies on ingest/crypto via mix-ins.

Because the lambda runs in ECS, we need to make sure those env vars are available. We can do that with this config:

```
envs:
  internal: <name of internal bucket>
  stackName: <name of deployment>
```

### CannontPullContainerError
Replicated the issue by following these guides to create a private subnet with a NAT gateway:

https://docs.aws.amazon.com/AmazonECS/latest/developerguide/create-public-private-vpc.html
https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Scenario2.html
Interestingly, if an ECS container instance has a public IP, these issues aren't seen when pulling a public docker image from docker hub.

If the container instance is on a private subnet like in the examples above, it needs a NAT gateway that provides internet access.

For some reason that I haven't figured out yet, in the case of a private subnet with NAT gateway, the ecs agent will try to authenticate no matter what, even if the docker image is public.

If the app/config.yml and app.env files don't specify valid docker credentials (email, username, password), login will fail.

The authentication will fail multiple times until we get a "too many failed logins" error: CannotPullContainerError: API error (500): Get https://registry-1.docker.io/v2/cumuluss/cumulus-ecs-task/manifests/1.1.1: toomanyrequests: too many failed login attempts for username or IP address

Right now our cloudformation template will append vales to the ecs config file, so if you deploy a template with incorrect credentials, then deploy again with correct credentials, the values will be appended to the config file, but the ecs agent may not read the new credentials.

So far I've found I have to delete the ECS container instance that has bad credentials, then redeploy the cloudformation template again with correct credentials. It's really easy to for the container instance to get in a bad state, so we need to check the config on the ec2 instance to make sure it is correct.