### PR TITLE
CUMULUS-602: Format all logs sent to Elastic Search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- **CUMULUS-602** - Format all logs sent to Elastic Search.
+  - Format the error message.
 
 ## [v1.1.1] - 2018-04-23
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [v1.1.2] - 2018-06-05
 ### Fixed
 - **CUMULUS-602** - Format all logs sent to Elastic Search.
   - Format the error message.
@@ -27,9 +29,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/cumulus-nasa/cumulus-cumulus-ecs-task/compare/v1.0.2...HEAD
-[v1.1.1]: https://github.com/cumulus-nasa/cumulus-cumulus-ecs-task/compare/v1.1.0...v1.1.1
-[v1.1.0]: https://github.com/cumulus-nasa/cumulus-cumulus-ecs-task/compare/v1.0.2...v1.1.0
-[v1.0.2]: https://github.com/cumulus-nasa/cumulus-cumulus-ecs-task/compare/v1.0.1...v1.0.2
-[v1.0.1]: https://github.com/cumulus-nasa/cumulus-cumulus-ecs-task/compare/v1.0.0...v1.0.1
+[Unreleased]: https://github.com/cumulus-nasa/cumulus-ecs-task/compare/v1.1.2...HEAD
+[v1.1.2]: https://github.com/cumulus-nasa/cumulus-ecs-task/compare/v1.1.1...v1.1.2
+[v1.1.1]: https://github.com/cumulus-nasa/cumulus-ecs-task/compare/v1.1.0...v1.1.1
+[v1.1.0]: https://github.com/cumulus-nasa/cumulus-ecs-task/compare/v1.0.2...v1.1.0
+[v1.0.2]: https://github.com/cumulus-nasa/cumulus-ecs-task/compare/v1.0.1...v1.0.2
+[v1.0.1]: https://github.com/cumulus-nasa/cumulus-ecs-task/compare/v1.0.0...v1.0.1
 [v1.0.0]: https://github.com/cumulus-nasa/cumulus-ecs-task/tree/v1.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/cumulus-ecs-task",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Run lambda functions in ECS",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Format the error messages.  Error message with newlines and no leading space or tab will result in separate log entry, and we replace the newline with a space.